### PR TITLE
Fix `websocket` connection by pinning `websockets` dependency version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+# Virtual environment
+venv
+.venv
+
+# Cache files
+__pycache__
+
+# IDE settings
+.vscode

--- a/example.py
+++ b/example.py
@@ -73,7 +73,7 @@ async def receive(websocket):
 async def connect_to_websocket():
     # generate random websocket key and headers
     websocket_key = ''.join(random.choices(string.ascii_uppercase + string.ascii_lowercase + string.digits, k=20))
-    extra_headers = {
+    additional_headers = {
         "Origin": "https://localhost", # If on the web, replace with streaming url
         "Sec-Websocket-Key": websocket_key,
         "Sec-Websocket-Version":"13",
@@ -86,7 +86,7 @@ async def connect_to_websocket():
                                                            number_of_channels=number_of_channels,
                                                            enable_channel_identification=channel_identification)
     async with websockets.connect(request_url, 
-                                  extra_headers=extra_headers, 
+                                  additional_headers=additional_headers, 
                                   ping_timeout=None,
                                   ) as websocket:  # Connect to the WebSocket
         await asyncio.gather(receive(websocket), send(websocket))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-websockets
+websockets==15.0.1


### PR DESCRIPTION
*Issue #, if available:*  
N/A

*Description of changes:*  
The current version of the `websockets` library (v15.0.1) introduces a change where the `extra_headers` argument has been renamed to `additional_headers`. To ensure compatibility with the existing codebase and avoid future breaking changes due to dependency updates, the `websockets` version is now pinned in `requirements.txt`.

This change prevents unexpected runtime errors caused by future major library updates, ensuring consistent behavior across all environments.

*Testing performed:*  
- Verified that the script successfully connects to Amazon Transcribe using the pinned `websockets==15.0.1`.  
- Confirmed that audio data is sent and transcription responses are received without errors.  

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution under the terms of your choice.  